### PR TITLE
add redirect from safedev.org to hub.safedev.org

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+https://safedev.org/* https://hub.safedev.org/:splat 301!


### PR DESCRIPTION
We were previously using CloudFlare to do this. Switching to Netlify will allow us to do this redirect without using a cookie. The SSL certificate doesn't seem to work for www.safedev.org at the moment but I think this issue will likely sort itself out on its own and I could do another PR later once it works. At least for now it would work for safedev.org which is what most people are likely to type.