### PR TITLE
add redirect from www.safedev.org to hub.safedev.org

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
 https://safedev.org/* https://hub.safedev.org/:splat 301!
+https://www.safedev.org/* https://hub.safedev.org/:splat 301!


### PR DESCRIPTION
The SSL certificate for hub.safedev.org and safedev.org now also works for www.safedev.org.