### PR TITLE
remove horizontal scroll on Core Technology page

### DIFF
--- a/src/sass/core_dev.sass
+++ b/src/sass/core_dev.sass
@@ -80,13 +80,6 @@
   color: $colr-white
   height: $graf-height
   word-break: keep-all
-  &:after
-    background-color: $colr-graf-dapp-f
-    content: "sdfsdf"
-    width: 234px
-    height: 8px
-    position: absolute
-    display: block
   &.dapp
     background-color: $colr-graf-dapp-b
     color: $colr-graf-dapp-f


### PR DESCRIPTION
I noticed that the Core Technology page lets the user scroll horizontally on mobile. So for example you would see something like this if you swipe left:

<img width="411" alt="Screen Shot 2019-11-13 at 2 38 16 PM" src="https://user-images.githubusercontent.com/1114844/68797845-45081100-0623-11ea-95c8-110ef916c69f.png">

This PR removes the styling that was causing this issue. It didn't seem to be used for anything in particular.