### PR TITLE
replace Crust with quic-p2p on Licensing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",
     "classnames": "^2.2.6",
-    "core-js": "^3.6.0",
+    "core-js": "^3.6.2",
     "html-react-parser": "^0.10.0",
     "js-yaml": "^3.13.1",
-    "prismjs": "^1.17.1",
+    "prismjs": "^1.18.0",
     "react-router-dom": "^5.1.2",
     "react-router-hash-link": "^1.2.2",
     "react-static": "7.1.0",

--- a/src/contents/en-gb/licensing.yaml
+++ b/src/contents/en-gb/licensing.yaml
@@ -7,18 +7,17 @@ intro:
       href: https://www.gnu.org/licenses/gpl-3.0.en.html
     chunk2: (GPLv3).
   list:
-    - Routing
-    - Safe_vault
-    - Safe_core
-    - Safe_authenticator
-    - Safe_authenticator_cli
-    - Self_encryption
+    - routing
+    - safe_vault
+    - safe_core
+    - safe_authenticator
+    - self_encryption
   para2: By doing this, we are ensuring that the fundamental aspects of the SAFE Network will be locked open and accessible to all. In practice, this means that developers building on (forking) MaidSafe’s core libraries must use the GPLv3 and publish all their source code.
   para3:
     chunk1: "There is one exception to this approach for the core libraries:"
     link1:
-      name: Crust
-      href: https://github.com/maidsafe/crust
+      name: quic-p2p
+      href: https://github.com/maidsafe/quic-p2p
     chunk2: ", a P2P network connections library, is licensed using either"
     link2:
       name: MIT
@@ -27,7 +26,7 @@ intro:
       name: BSD
       href: https://opensource.org/licenses/BSD-3-Clause
     chunk3: or
-    chunk4: "(Modified). This library is potentially very useful to any project that needs a network connections library for a server-less, decentralised project. Therefore, in order to ensure that this library is used as widely as possible, we’ve chosen these permissive licences as they ensure that developers building on Crust receive the maximum flexibility in the sense that they can then select whatever licence they choose."
+    chunk4: "(Modified). This library is potentially very useful to any project that needs a network connections library for a server-less, decentralised project. Therefore, in order to ensure that this library is used as widely as possible, we’ve chosen these permissive licences as they ensure that developers building on quic-p2p receive the maximum flexibility in the sense that they can then select whatever licence they choose."
 useOfApi:
   title: Use of APIs
   para: All other SAFE libraries, including the APIs and bindings, are licensed using both the MIT and BSD (Modified) licence.  In addition, any app that uses the bindings is allowed to choose any licence for their app/product. The reason for this is that the app is only making API calls on the network as opposed to integrating directly with the libraries.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,10 +2355,10 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
   integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
 
-core-js@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.0.tgz#2b854e451de1967d1e29896025cdc13a2518d9ea"
-  integrity sha512-AHPTNKzyB+YwgDWoSOCaid9PUSEF6781vsfiK8qUz62zRR448/XgK2NtCbpiUGizbep8Lrpt0Du19PpGGZvw3Q==
+core-js@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.2.tgz#2799ea1a59050f0acf50dfe89b916d6503b16caa"
+  integrity sha512-hIE5dXkRzRvnZ5vhkRfQxUvDxQZmD9oueA08jDYRBKJHx+VIl/Pne/e0A4x9LObEEthC/TqiZybUoNM4tRgnKg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -6525,10 +6525,10 @@ pretty-error@^2.0.2, pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-prismjs@^1.17.1:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.17.1.tgz#e669fcbd4cdd873c35102881c33b14d0d68519be"
-  integrity sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==
+prismjs@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.18.0.tgz#8f04dd47fa232cbd27d1ca969107580ff43f06e4"
+  integrity sha512-N0r3i/Cto516V8+GKKamhsPVZSFcO0TMUBtIDW6uq6BVqoC3FNtZVZ+cmH16N2XtGQlgRN+sFUTjOdCsEP51qw==
   optionalDependencies:
     clipboard "^2.0.0"
 


### PR DESCRIPTION
Also remove reference to safe-authenticator-cli since it's now deprecated.

I was also wondering if there are other libraries we should add to this list (e.g. parsec).

> There is one exception to this approach for the core libraries:

Technically there are other core libraries that are not GPLv3. E.g. safe-nd is also MIT / BSD.

Also we mention that:

> All other SAFE libraries, including the APIs and bindings, are licensed using both the MIT and BSD (Modified) licence.

But I noticed that safe-api, safe-cli, etc. are GPLv3. Not sure why.

Anyway, these issues could be addressed later. I thought I would just make this simple PR for now considering that we now use quic-p2p instead of Crust.

