### PR TITLE
add parsec to Licensing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,3 @@ $ yarn serve
 # License
 
 This SAFE Network repository is dual-licensed under the Modified BSD ([LICENSE-BSD](LICENSE-BSD) https://opensource.org/licenses/BSD-3-Clause) or the MIT license ([LICENSE-MIT](LICENSE-MIT) https://opensource.org/licenses/MIT) at your option.
-
-# Contribution
-
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the
-work by you, as defined in the MaidSafe Contributor Agreement, version 1.1 ([CONTRIBUTOR]
-(CONTRIBUTOR)), shall be dual licensed as above, and you agree to be bound by the terms of the
-MaidSafe Contributor Agreement, version 1.1.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev_website",
   "private": true,
-  "license": "GPL-3.0-only",
+  "license": "(MIT OR BSD-3-Clause)",
   "scripts": {
     "start": "react-static start",
     "stage": "react-static build --staging",

--- a/src/contents/en-gb/licensing.yaml
+++ b/src/contents/en-gb/licensing.yaml
@@ -8,6 +8,7 @@ intro:
     chunk2: (GPLv3).
   list:
     - routing
+    - parsec
     - safe_vault
     - safe_core
     - safe_authenticator


### PR DESCRIPTION
Also removes Contributor Agreement (we don't have one anymore, see Core contributions section on https://hub.safedev.org/licensing/).